### PR TITLE
Fix Syntax Error PKGBUILD

### DIFF
--- a/Archlinux/nvidia-304.137/nvidia-304xx-utils/PKGBUILD
+++ b/Archlinux/nvidia-304.137/nvidia-304xx-utils/PKGBUILD
@@ -8,7 +8,7 @@ pkgver=304.137
 pkgrel=5
 arch=('x86_64')
 url="http://www.nvidia.com/"
-makedepends("patchelf")
+makedepends=("patchelf")
 license=('custom')
 options=('!strip')
 source=('nvidia-drm-outputclass.conf' 'nvidia-utils.sysusers')


### PR DESCRIPTION
/nvidia-304/Archlinux/nvidia-304.137/nvidia-304xx-utils/PKGBUILD: line 11: syntax error near unexpected token "patchelf"'
/nvidia-304/Archlinux/nvidia-304.137/nvidia-304xx-utils/PKGBUILD: line 11: makedepends("patchelf")'
==> ERROR: Failed to source /nvidia-304/Archlinux/nvidia-304.137/nvidia-304xx-utils/PKGBUILD

